### PR TITLE
Состояние медиафайла. Kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,15 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/pipemasters/server/config/KafkaConfig.java
+++ b/src/main/java/com/pipemasters/server/config/KafkaConfig.java
@@ -1,0 +1,10 @@
+package com.pipemasters.server.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+}

--- a/src/main/java/com/pipemasters/server/controller/AudioController.java
+++ b/src/main/java/com/pipemasters/server/controller/AudioController.java
@@ -28,7 +28,7 @@ public class AudioController {
 
     }
 
-    @PostMapping("/minio-event")
+//    @PostMapping("/minio-event")
     public ResponseEntity<Void> handleMinioEvent(
             @RequestBody Map<String, Object> payload,
             @RequestHeader(value = "Authorization", required = false) String auth) {

--- a/src/main/java/com/pipemasters/server/entity/MediaFile.java
+++ b/src/main/java/com/pipemasters/server/entity/MediaFile.java
@@ -1,6 +1,7 @@
 package com.pipemasters.server.entity;
 
 import com.pipemasters.server.entity.enums.FileType;
+import com.pipemasters.server.entity.enums.MediaFileStatus;
 import jakarta.persistence.*;
 
 import java.time.Instant;
@@ -16,6 +17,11 @@ public class MediaFile extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 16)
     private FileType fileType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private MediaFileStatus status = MediaFileStatus.PENDING;
+
 
     @Column(nullable = false, updatable = false)
     private Instant uploadedAt = Instant.now();
@@ -84,5 +90,13 @@ public class MediaFile extends BaseEntity {
 
     public void setUploadBatch(UploadBatch uploadBatch) {
         this.uploadBatch = uploadBatch;
+    }
+
+    public MediaFileStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(MediaFileStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/pipemasters/server/entity/enums/MediaFileStatus.java
+++ b/src/main/java/com/pipemasters/server/entity/enums/MediaFileStatus.java
@@ -1,0 +1,9 @@
+package com.pipemasters.server.entity.enums;
+
+public enum MediaFileStatus {
+    PENDING,
+    UPLOADED,
+    PROCESSING,
+    PROCESSED,
+    FAILED
+}

--- a/src/main/java/com/pipemasters/server/kafka/KafkaProducerService.java
+++ b/src/main/java/com/pipemasters/server/kafka/KafkaProducerService.java
@@ -1,0 +1,21 @@
+package com.pipemasters.server.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaProducerService {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Logger log = LoggerFactory.getLogger(KafkaProducerService.class);
+
+    public KafkaProducerService(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void send(String topic, String message) {
+        log.debug("Sending message to {}: {}", topic, message);
+        kafkaTemplate.send(topic, message);
+    }
+}

--- a/src/main/java/com/pipemasters/server/kafka/MinioEventConsumer.java
+++ b/src/main/java/com/pipemasters/server/kafka/MinioEventConsumer.java
@@ -1,0 +1,59 @@
+package com.pipemasters.server.kafka;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pipemasters.server.entity.MediaFile;
+import com.pipemasters.server.entity.enums.FileType;
+import com.pipemasters.server.entity.enums.MediaFileStatus;
+import com.pipemasters.server.repository.MediaFileRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class MinioEventConsumer {
+    private final Logger log = LoggerFactory.getLogger(MinioEventConsumer.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MediaFileRepository mediaFileRepository;
+    private final KafkaProducerService producerService;
+
+    public MinioEventConsumer(MediaFileRepository mediaFileRepository, KafkaProducerService producerService) {
+        this.mediaFileRepository = mediaFileRepository;
+        this.producerService = producerService;
+    }
+
+    @KafkaListener(topics = "minio.raw-events")
+    @Transactional
+    public void handle(String message) throws Exception {
+        JsonNode root = objectMapper.readTree(message);
+        JsonNode records = root.path("Records");
+        log.debug("Received Minio event: {}", root.toPrettyString());
+        if (records.isArray()) {
+            for (JsonNode record : records) {
+                String eventName = record.path("eventName").asText();
+                if (eventName.startsWith("s3:ObjectCreated:")) {
+                    String key = record.path("s3").path("object").path("key").asText();
+                    String[] parts = key.split("/", 2);
+                    if (parts.length != 2) continue;
+                    String batch = parts[0];
+                    String filename = parts[1];
+                    Optional<MediaFile> opt = mediaFileRepository.findByFilenameAndUploadBatchDirectory(filename, UUID.fromString(batch));
+                    if (opt.isPresent()) {
+                        MediaFile file = opt.get();
+                        file.setStatus(MediaFileStatus.UPLOADED);
+                        if (file.getFileType() == FileType.VIDEO) {
+                            producerService.send("processing-queue", file.getId().toString());
+                        }
+                    } else {
+                        log.warn("MediaFile not found for key {}", key);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/pipemasters/server/kafka/ProcessingQueueConsumer.java
+++ b/src/main/java/com/pipemasters/server/kafka/ProcessingQueueConsumer.java
@@ -1,0 +1,43 @@
+package com.pipemasters.server.kafka;
+
+import com.pipemasters.server.entity.MediaFile;
+import com.pipemasters.server.entity.enums.MediaFileStatus;
+import com.pipemasters.server.repository.MediaFileRepository;
+import com.pipemasters.server.service.AudioService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProcessingQueueConsumer {
+    private final Logger log = LoggerFactory.getLogger(ProcessingQueueConsumer.class);
+    private final MediaFileRepository mediaFileRepository;
+    private final AudioService audioService;
+    private final KafkaProducerService producerService;
+
+    public ProcessingQueueConsumer(MediaFileRepository mediaFileRepository,
+                                   AudioService audioService,
+                                   KafkaProducerService producerService) {
+        this.mediaFileRepository = mediaFileRepository;
+        this.audioService = audioService;
+        this.producerService = producerService;
+    }
+
+    @KafkaListener(topics = "processing-queue")
+    @Transactional
+    public void process(String message) {
+        Long id = Long.valueOf(message);
+        MediaFile file = mediaFileRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Media file not found: " + id));
+        file.setStatus(MediaFileStatus.PROCESSING);
+        mediaFileRepository.save(file);
+        log.info("Processing media file with ID: {}", id);
+        audioService.extractAudio(id).join();
+        file.setStatus(MediaFileStatus.PROCESSED);
+        mediaFileRepository.save(file);
+        log.info("Finished processing media file with ID: {}", id);
+        producerService.send("processed", id.toString());
+    }
+}

--- a/src/main/java/com/pipemasters/server/kafka/ProcessingQueueConsumer.java
+++ b/src/main/java/com/pipemasters/server/kafka/ProcessingQueueConsumer.java
@@ -33,10 +33,12 @@ public class ProcessingQueueConsumer {
                 .orElseThrow(() -> new IllegalArgumentException("Media file not found: " + id));
         file.setStatus(MediaFileStatus.PROCESSING);
         mediaFileRepository.save(file);
+        log.debug("Media file with ID {} status updated to {}", id, file.getStatus());
         log.info("Processing media file with ID: {}", id);
         audioService.extractAudio(id).join();
         file.setStatus(MediaFileStatus.PROCESSED);
         mediaFileRepository.save(file);
+        log.debug("Media file with ID {} status updated to {}", id, file.getStatus());
         log.info("Finished processing media file with ID: {}", id);
         producerService.send("processed", id.toString());
     }

--- a/src/main/java/com/pipemasters/server/kafka/ProcessingTask.java
+++ b/src/main/java/com/pipemasters/server/kafka/ProcessingTask.java
@@ -1,0 +1,20 @@
+package com.pipemasters.server.kafka;
+
+public class ProcessingTask {
+    private Long mediaFileId;
+
+    public ProcessingTask() {
+    }
+
+    public ProcessingTask(Long mediaFileId) {
+        this.mediaFileId = mediaFileId;
+    }
+
+    public Long getMediaFileId() {
+        return mediaFileId;
+    }
+
+    public void setMediaFileId(Long mediaFileId) {
+        this.mediaFileId = mediaFileId;
+    }
+}

--- a/src/main/java/com/pipemasters/server/repository/MediaFileRepository.java
+++ b/src/main/java/com/pipemasters/server/repository/MediaFileRepository.java
@@ -10,4 +10,6 @@ public interface MediaFileRepository extends GeneralRepository<MediaFile, Long> 
     void deleteById(Long id);
     @Query("select m from MediaFile m where m.filename = :filename and m.uploadBatch.directory = :uploadBatchDirectory")
     Optional<MediaFile> findByFilenameAndUploadBatchDirectory(String filename, UUID uploadBatchDirectory);
+    @Query("select (count(m) > 0) from MediaFile m where m.filename = :filename and m.uploadBatch.directory = :uploadBatchDirectory")
+    boolean existsByFilenameAndUploadBatchDirectory(String filename, UUID uploadBatchDirectory);
 }

--- a/src/main/java/com/pipemasters/server/service/impl/AudioServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/AudioServiceImpl.java
@@ -88,7 +88,9 @@ public class AudioServiceImpl implements AudioService {
                     throw new IllegalStateException("FFmpeg exited with status " + exit);
                 }
 
-                String targetName = source.getFilename() + "_audio.mp3";
+                String sourceFileName = source.getFilename().substring(0, source.getFilename().lastIndexOf('.'));
+
+                String targetName = sourceFileName + "_audio.mp3";
 
                 FileUploadRequestDto uploadDto = new FileUploadRequestDto(
                         source.getUploadBatch().getId(), targetName, FileType.AUDIO, mediaFileId);

--- a/src/main/java/com/pipemasters/server/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/FileServiceImpl.java
@@ -3,6 +3,7 @@ package com.pipemasters.server.service.impl;
 import com.pipemasters.server.dto.FileUploadRequestDto;
 import com.pipemasters.server.entity.UploadBatch;
 import com.pipemasters.server.entity.MediaFile;
+import com.pipemasters.server.entity.enums.MediaFileStatus;
 import com.pipemasters.server.repository.MediaFileRepository;
 import com.pipemasters.server.repository.UploadBatchRepository;
 import com.pipemasters.server.service.FileService;
@@ -47,11 +48,12 @@ public class FileServiceImpl implements FileService {
                 .orElseThrow(() -> new RuntimeException("UploadBatch not found with ID: " + fileUploadRequestDTO.getUploadBatchId()));
 
         String s3Key = fileUploadRequestDTO.getFilename();
-        logger.debug("Generated S3 key: {}", uploadBatch.getDirectory() + "/" + s3Key);
+        logger.debug("Generated S3 key for uploadUrl: {}", uploadBatch.getDirectory() + "/" + s3Key);
         MediaFile mediaFile = new MediaFile();
         mediaFile.setFilename(s3Key);
         mediaFile.setFileType(fileUploadRequestDTO.getFileType());
         mediaFile.setUploadBatch(uploadBatch);
+        mediaFile.setStatus(MediaFileStatus.PENDING);
         if (fileUploadRequestDTO.getSourceId() != null) {
             mediaFile.setSource(mediaFileRepository.findById(fileUploadRequestDTO.getSourceId()).orElseThrow(() -> new RuntimeException("Source MediaFile not found with ID: " + fileUploadRequestDTO.getSourceId())));
         }
@@ -78,7 +80,7 @@ public class FileServiceImpl implements FileService {
                 .orElseThrow(() -> new RuntimeException("MediaFile not found with ID: " + mediaFileId));
 
         String s3Key = mediaFile.getUploadBatch().getDirectory() + "/" + mediaFile.getFilename();
-        logger.debug("Generated S3 key for download: {}", s3Key);
+        logger.debug("Generated S3 key for downloadUrl: {}", s3Key);
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(minioBucketName)
                 .key(s3Key)

--- a/src/main/java/com/pipemasters/server/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/FileServiceImpl.java
@@ -48,6 +48,9 @@ public class FileServiceImpl implements FileService {
 
         String s3Key = fileUploadRequestDTO.getFilename();
         logger.debug("Generated S3 key for uploadUrl: {}", uploadBatch.getDirectory() + "/" + s3Key);
+        if (mediaFileRepository.existsByFilenameAndUploadBatchDirectory(fileUploadRequestDTO.getFilename(), uploadBatch.getDirectory())) {
+            throw new RuntimeException("File with the same name already exists in this upload batch.");
+        }
         MediaFile mediaFile = new MediaFile();
         mediaFile.setFilename(s3Key);
         mediaFile.setFileType(fileUploadRequestDTO.getFileType());

--- a/src/main/java/com/pipemasters/server/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/FileServiceImpl.java
@@ -33,7 +33,6 @@ public class FileServiceImpl implements FileService {
     private final UploadBatchRepository uploadBatchRepository;
     private final Logger logger = LoggerFactory.getLogger(FileServiceImpl.class);
 
-    //    @Autowired
     public FileServiceImpl(S3Presigner s3Presigner, String minioBucketName, MediaFileRepository mediaFileRepository, UploadBatchRepository uploadBatchRepository) {
         this.s3Presigner = s3Presigner;
         this.minioBucketName = minioBucketName;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ minio.endpoint=${MINIO_ENDPOINT}
 minio.access-key=${MINIO_ACCESS_KEY}
 minio.secret-key=${MINIO_SECRET_KEY}
 minio.bucket=dev-bucket
+
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+spring.kafka.consumer.group-id=server-group
+spring.kafka.consumer.auto-offset-reset=earliest

--- a/src/test/java/com/pipemasters/server/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/com/pipemasters/server/kafka/KafkaProducerServiceTest.java
@@ -1,0 +1,33 @@
+package com.pipemasters.server.kafka;
+
+import com.pipemasters.server.kafka.KafkaProducerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class KafkaProducerServiceTest {
+
+    private KafkaTemplate<String, String> kafkaTemplate;
+    private KafkaProducerService producerService;
+
+    @BeforeEach
+    void setUp() {
+        kafkaTemplate = mock(KafkaTemplate.class);
+        producerService = new KafkaProducerService(kafkaTemplate);
+    }
+
+    @Test
+    void send_shouldSendMessageToKafka() {
+        String topic = "test-topic";
+        String message = "test-message";
+
+        producerService.send(topic, message);
+
+        verify(kafkaTemplate, times(1)).send(topic, message);
+    }
+}

--- a/src/test/java/com/pipemasters/server/kafka/MinioEventConsumerTest.java
+++ b/src/test/java/com/pipemasters/server/kafka/MinioEventConsumerTest.java
@@ -1,0 +1,67 @@
+package com.pipemasters.server.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pipemasters.server.entity.MediaFile;
+import com.pipemasters.server.entity.enums.FileType;
+import com.pipemasters.server.entity.enums.MediaFileStatus;
+import com.pipemasters.server.kafka.KafkaProducerService;
+import com.pipemasters.server.kafka.MinioEventConsumer;
+import com.pipemasters.server.repository.MediaFileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MinioEventConsumerTest {
+
+    private MediaFileRepository mediaFileRepository;
+    private KafkaProducerService producerService;
+    private MinioEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        mediaFileRepository = mock(MediaFileRepository.class);
+        producerService = mock(KafkaProducerService.class);
+        consumer = new MinioEventConsumer(mediaFileRepository, producerService);
+    }
+
+    @Test
+    void handle_shouldUpdateStatusAndSendToProcessingQueue_whenVideoUploaded() throws Exception {
+        UUID batchId = UUID.randomUUID();
+        String filename = "video.mp4";
+        String key = batchId + "/" + filename;
+        String message = "{ \"Records\": [ { \"eventName\": \"s3:ObjectCreated:Put\", \"s3\": { \"object\": { \"key\": \"" + key + "\" } } } ] }";
+
+        MediaFile file = new MediaFile();
+        file.setId(42L);
+        file.setFilename(filename);
+        file.setFileType(FileType.VIDEO);
+
+        when(mediaFileRepository.findByFilenameAndUploadBatchDirectory(filename, batchId)).thenReturn(Optional.of(file));
+
+        consumer.handle(message);
+
+        verify(mediaFileRepository).save(file);
+        verify(producerService).send("processing-queue", "42");
+        assertEquals(MediaFileStatus.UPLOADED, file.getStatus());
+    }
+
+    @Test
+    void handle_shouldNotThrow_whenNoMatchingFile() throws Exception {
+        UUID batchId = UUID.randomUUID();
+        String filename = "notfound.mp4";
+        String key = batchId + "/" + filename;
+        String message = "{ \"Records\": [ { \"eventName\": \"s3:ObjectCreated:Put\", \"s3\": { \"object\": { \"key\": \"" + key + "\" } } } ] }";
+
+        when(mediaFileRepository.findByFilenameAndUploadBatchDirectory(filename, batchId)).thenReturn(Optional.empty());
+
+        consumer.handle(message);
+
+        verify(mediaFileRepository, never()).save(any());
+        verify(producerService, never()).send(anyString(), anyString());
+    }
+}

--- a/src/test/java/com/pipemasters/server/kafka/ProcessingQueueConsumerTest.java
+++ b/src/test/java/com/pipemasters/server/kafka/ProcessingQueueConsumerTest.java
@@ -1,0 +1,50 @@
+package com.pipemasters.server.kafka;
+
+import com.pipemasters.server.entity.MediaFile;
+import com.pipemasters.server.entity.enums.MediaFileStatus;
+import com.pipemasters.server.kafka.KafkaProducerService;
+import com.pipemasters.server.kafka.ProcessingQueueConsumer;
+import com.pipemasters.server.repository.MediaFileRepository;
+import com.pipemasters.server.service.AudioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ProcessingQueueConsumerTest {
+
+    private MediaFileRepository mediaFileRepository;
+    private AudioService audioService;
+    private KafkaProducerService producerService;
+    private ProcessingQueueConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        mediaFileRepository = mock(MediaFileRepository.class);
+        audioService = mock(AudioService.class);
+        producerService = mock(KafkaProducerService.class);
+        consumer = new ProcessingQueueConsumer(mediaFileRepository, audioService, producerService);
+    }
+
+    @Test
+    void process_shouldUpdateStatusAndCallAudioService() {
+        Long id = 1L;
+        MediaFile file = new MediaFile();
+        file.setId(id);
+        file.setStatus(MediaFileStatus.PENDING);
+
+        when(mediaFileRepository.findById(id)).thenReturn(Optional.of(file));
+        when(audioService.extractAudio(id)).thenReturn(CompletableFuture.completedFuture("done"));
+
+        consumer.process(id.toString());
+
+        verify(mediaFileRepository, times(2)).save(file);
+        verify(audioService).extractAudio(id);
+        verify(producerService).send("processed", id.toString());
+        assertEquals(MediaFileStatus.PROCESSED, file.getStatus());
+    }
+}

--- a/src/test/java/com/pipemasters/server/kafka/ProcessingTaskTest.java
+++ b/src/test/java/com/pipemasters/server/kafka/ProcessingTaskTest.java
@@ -1,0 +1,22 @@
+package com.pipemasters.server.kafka;
+
+import com.pipemasters.server.kafka.ProcessingTask;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProcessingTaskTest {
+
+    @Test
+    void testNoArgsConstructorAndSetters() {
+        ProcessingTask task = new ProcessingTask();
+        task.setMediaFileId(123L);
+        assertEquals(123L, task.getMediaFileId());
+    }
+
+    @Test
+    void testAllArgsConstructor() {
+        ProcessingTask task = new ProcessingTask(456L);
+        assertEquals(456L, task.getMediaFileId());
+    }
+}


### PR DESCRIPTION
Добавил enum для указания текущего состояния файла на Minio.

Вместо ВебХука теперь для получения эвентов из Minio используется Kafka.
Также задачи на обработку видеофайла поступают в топики, где поглощаются.
Есть некие тесты.
В сервисе генерации ссылок добавил проверку на дубликат файла.

docker-compose.yaml лежит на сервере вот тут /opt/dev/minio/docker-compose.yaml 
Содержит minio, kafka, zookeeper.