### PR TITLE
Старая версия springdoc. Теперь новая

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.5.0</version>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.kafka</groupId>


### PR DESCRIPTION
Изменил версию с 2.5.0 на 2.8.9. В ином случае swagger не работал.