### PR TITLE
add endpoint to get mediaFiles by uploadBatch ID

### DIFF
--- a/src/main/java/com/pipemasters/server/controller/MediaFileController.java
+++ b/src/main/java/com/pipemasters/server/controller/MediaFileController.java
@@ -1,0 +1,28 @@
+package com.pipemasters.server.controller;
+
+import com.pipemasters.server.dto.MediaFileResponseDto;
+import com.pipemasters.server.service.MediaFileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/media-files")
+public class MediaFileController {
+
+    private final MediaFileService mediaFileService;
+
+    public MediaFileController(MediaFileService mediaFileService) {
+        this.mediaFileService = mediaFileService;
+    }
+
+    @GetMapping("/by-batch/{uploadBatchId}")
+    public ResponseEntity<List<MediaFileResponseDto>> getAllMediaFilesByUploadBatch(@PathVariable Long uploadBatchId) {
+        List<MediaFileResponseDto> mediaFiles = mediaFileService.getMediaFilesByUploadBatchId(uploadBatchId);
+        return ResponseEntity.ok(mediaFiles);
+    }
+}

--- a/src/main/java/com/pipemasters/server/dto/MediaFileResponseDto.java
+++ b/src/main/java/com/pipemasters/server/dto/MediaFileResponseDto.java
@@ -1,0 +1,56 @@
+package com.pipemasters.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.pipemasters.server.entity.enums.FileType;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MediaFileResponseDto extends BaseDto{
+    private String filename;
+    private FileType fileType;
+    private Instant uploadedAt;
+    private MediaFileResponseDto source;
+
+    public MediaFileResponseDto() {
+    }
+
+    public MediaFileResponseDto(String filename, FileType fileType, Instant uploadedAt, MediaFileResponseDto source) {
+        this.filename = filename;
+        this.fileType = fileType;
+        this.uploadedAt = uploadedAt;
+        this.source = source;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public FileType getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(FileType fileType) {
+        this.fileType = fileType;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+
+    public MediaFileResponseDto getSource() {
+        return source;
+    }
+
+    public void setSource(MediaFileResponseDto source) {
+        this.source = source;
+    }
+}

--- a/src/main/java/com/pipemasters/server/repository/MediaFileRepository.java
+++ b/src/main/java/com/pipemasters/server/repository/MediaFileRepository.java
@@ -3,6 +3,7 @@ package com.pipemasters.server.repository;
 import com.pipemasters.server.entity.MediaFile;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +13,6 @@ public interface MediaFileRepository extends GeneralRepository<MediaFile, Long> 
     Optional<MediaFile> findByFilenameAndUploadBatchDirectory(String filename, UUID uploadBatchDirectory);
     @Query("select (count(m) > 0) from MediaFile m where m.filename = :filename and m.uploadBatch.directory = :uploadBatchDirectory")
     boolean existsByFilenameAndUploadBatchDirectory(String filename, UUID uploadBatchDirectory);
+    @Query("select m from MediaFile m where m.uploadBatch.id = :uploadBatchId")
+    List<MediaFile> findByUploadBatchId(Long uploadBatchId);
 }

--- a/src/main/java/com/pipemasters/server/service/MediaFileService.java
+++ b/src/main/java/com/pipemasters/server/service/MediaFileService.java
@@ -1,0 +1,10 @@
+package com.pipemasters.server.service;
+
+
+import com.pipemasters.server.dto.MediaFileResponseDto;
+
+import java.util.List;
+
+public interface MediaFileService {
+    List<MediaFileResponseDto> getMediaFilesByUploadBatchId(Long uploadBatchId);
+}

--- a/src/main/java/com/pipemasters/server/service/impl/MediaFileServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/MediaFileServiceImpl.java
@@ -1,0 +1,26 @@
+package com.pipemasters.server.service.impl;
+
+import com.pipemasters.server.dto.MediaFileResponseDto;
+import com.pipemasters.server.repository.MediaFileRepository;
+import com.pipemasters.server.service.MediaFileService;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MediaFileServiceImpl implements MediaFileService {
+    private final MediaFileRepository mediaFileRepository;
+    private final ModelMapper modelMapper;
+
+    public MediaFileServiceImpl(MediaFileRepository mediaFileRepository, ModelMapper modelMapper) {
+        this.mediaFileRepository = mediaFileRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    @Override
+    public List<MediaFileResponseDto> getMediaFilesByUploadBatchId(Long uploadBatchId) {
+        return mediaFileRepository.findByUploadBatchId(uploadBatchId).stream().map(m ->
+                modelMapper.map(m, MediaFileResponseDto.class)).toList();
+    }
+}

--- a/src/test/java/com/pipemasters/server/controller/MediaFileControllerTest.java
+++ b/src/test/java/com/pipemasters/server/controller/MediaFileControllerTest.java
@@ -1,0 +1,76 @@
+package com.pipemasters.server.controller;
+
+import com.pipemasters.server.dto.MediaFileResponseDto;
+import com.pipemasters.server.service.MediaFileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaFileControllerTest {
+
+    @Mock
+    private MediaFileService mediaFileService;
+
+    @InjectMocks
+    private MediaFileController mediaFileController;
+
+    private Long testUploadBatchId;
+    private MediaFileResponseDto file1;
+    private MediaFileResponseDto file2;
+
+    @BeforeEach
+    void setUp() {
+        testUploadBatchId = 123L;
+        file1 = new MediaFileResponseDto();
+        file2 = new MediaFileResponseDto();
+
+         file1.setId(1L);
+         file1.setFilename("video1.mp4");
+         file2.setId(2L);
+         file2.setFilename("video2.mp4");
+    }
+
+    @Test
+    void getAllMediaFilesByUploadBatch_shouldReturnListOfMediaFiles() {
+        List<MediaFileResponseDto> expectedFiles = Arrays.asList(file1, file2);
+        when(mediaFileService.getMediaFilesByUploadBatchId(testUploadBatchId))
+                .thenReturn(expectedFiles);
+
+        ResponseEntity<List<MediaFileResponseDto>> response =
+                mediaFileController.getAllMediaFilesByUploadBatch(testUploadBatchId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(2, response.getBody().size());
+        assertEquals(expectedFiles, response.getBody());
+    }
+
+    @Test
+    void getAllMediaFilesByUploadBatch_shouldReturnEmptyListWhenNoFilesFound() {
+        when(mediaFileService.getMediaFilesByUploadBatchId(testUploadBatchId))
+                .thenReturn(List.of());
+
+        ResponseEntity<List<MediaFileResponseDto>> response =
+                mediaFileController.getAllMediaFilesByUploadBatch(testUploadBatchId);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(0, response.getBody().size());
+        assertEquals(List.of(), response.getBody());
+    }
+}

--- a/src/test/java/com/pipemasters/server/repository/MediaFileRepositoryTest.java
+++ b/src/test/java/com/pipemasters/server/repository/MediaFileRepositoryTest.java
@@ -237,4 +237,45 @@ public class MediaFileRepositoryTest {
         Optional<MediaFile> found = mediaFileRepository.findByFilenameAndUploadBatchDirectory("shared.mp4", batch2.getDirectory());
         assertTrue(found.isEmpty());
     }
+
+    @Test
+    void findByUploadBatchIdReturnsCorrectMediaFiles() {
+        UploadBatch batch1 = createUploadBatch();
+        UploadBatch batch2 = createUploadBatch();
+
+        MediaFile file1Batch1 = mediaFileRepository.save(new MediaFile("file1_b1.mp4", FileType.VIDEO, batch1));
+        MediaFile file2Batch1 = mediaFileRepository.save(new MediaFile("file2_b1.mp3", FileType.AUDIO, batch1));
+        MediaFile file1Batch2 = mediaFileRepository.save(new MediaFile("file1_b2.jpg", FileType.IMAGE, batch2));
+
+        List<MediaFile> foundFilesForBatch1 = mediaFileRepository.findByUploadBatchId(batch1.getId());
+        assertNotNull(foundFilesForBatch1);
+        assertEquals(2, foundFilesForBatch1.size());
+        assertTrue(foundFilesForBatch1.contains(file1Batch1));
+        assertTrue(foundFilesForBatch1.contains(file2Batch1));
+        assertFalse(foundFilesForBatch1.contains(file1Batch2));
+
+        List<MediaFile> foundFilesForBatch2 = mediaFileRepository.findByUploadBatchId(batch2.getId());
+        assertNotNull(foundFilesForBatch2);
+        assertEquals(1, foundFilesForBatch2.size());
+        assertTrue(foundFilesForBatch2.contains(file1Batch2));
+        assertFalse(foundFilesForBatch2.contains(file1Batch1));
+    }
+
+    @Test
+    void findByUploadBatchIdReturnsEmptyListForBatchWithNoFiles() {
+        UploadBatch batchWithNoFiles = createUploadBatch();
+
+        List<MediaFile> foundFiles = mediaFileRepository.findByUploadBatchId(batchWithNoFiles.getId());
+        assertNotNull(foundFiles);
+        assertTrue(foundFiles.isEmpty());
+    }
+
+    @Test
+    void findByUploadBatchIdReturnsEmptyListForNonExistentBatchId() {
+        Long nonExistentBatchId = 999999L;
+
+        List<MediaFile> foundFiles = mediaFileRepository.findByUploadBatchId(nonExistentBatchId);
+        assertNotNull(foundFiles);
+        assertTrue(foundFiles.isEmpty());
+    }
 }

--- a/src/test/java/com/pipemasters/server/service/MediaFileServiceTest.java
+++ b/src/test/java/com/pipemasters/server/service/MediaFileServiceTest.java
@@ -1,0 +1,92 @@
+package com.pipemasters.server.service;
+
+import com.pipemasters.server.dto.MediaFileResponseDto;
+import com.pipemasters.server.entity.MediaFile;
+import com.pipemasters.server.repository.MediaFileRepository;
+import com.pipemasters.server.service.impl.MediaFileServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaFileServiceTest {
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private MediaFileServiceImpl mediaFileService;
+
+    private Long testUploadBatchId;
+    private MediaFile mockMediaFile1;
+    private MediaFile mockMediaFile2;
+    private MediaFileResponseDto mockDto1;
+    private MediaFileResponseDto mockDto2;
+
+    @BeforeEach
+    void setUp() {
+        testUploadBatchId = 1L;
+
+        mockMediaFile1 = new MediaFile();
+         mockMediaFile1.setId(101L);
+         mockMediaFile1.setFilename("file1.mp4");
+
+        mockMediaFile2 = new MediaFile();
+         mockMediaFile2.setId(102L);
+         mockMediaFile2.setFilename("file2.mp3");
+
+        mockDto1 = new MediaFileResponseDto();
+         mockDto1.setId(101L);
+         mockDto1.setFilename("file1.mp4");
+
+        mockDto2 = new MediaFileResponseDto();
+         mockDto2.setId(102L);
+         mockDto2.setFilename("file2.mp3");
+    }
+
+    @Test
+    void getMediaFilesByUploadBatchId_shouldReturnMappedMediaFiles() {
+        List<MediaFile> repoReturnList = Arrays.asList(mockMediaFile1, mockMediaFile2);
+        when(mediaFileRepository.findByUploadBatchId(testUploadBatchId))
+                .thenReturn(repoReturnList);
+
+        when(modelMapper.map(mockMediaFile1, MediaFileResponseDto.class))
+                .thenReturn(mockDto1);
+        when(modelMapper.map(mockMediaFile2, MediaFileResponseDto.class))
+                .thenReturn(mockDto2);
+
+        List<MediaFileResponseDto> result = mediaFileService.getMediaFilesByUploadBatchId(testUploadBatchId);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(mockDto1, result.get(0));
+        assertEquals(mockDto2, result.get(1));
+    }
+
+    @Test
+    void getMediaFilesByUploadBatchId_shouldReturnEmptyListWhenNoFilesFound() {
+        when(mediaFileRepository.findByUploadBatchId(testUploadBatchId))
+                .thenReturn(Collections.emptyList());
+
+        List<MediaFileResponseDto> result = mediaFileService.getMediaFilesByUploadBatchId(testUploadBatchId);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
Добавлено получение всех медиафайлов привязанных к конкретной UploadBatch(по id)