### PR TITLE
Добавление методов поиска в branch controller

### DIFF
--- a/src/main/java/com/pipemasters/server/controller/BranchController.java
+++ b/src/main/java/com/pipemasters/server/controller/BranchController.java
@@ -66,4 +66,9 @@ public class BranchController {
         List<BranchDto> childBranches = branchService.getChildBranches(parentId, includeParent);
         return ResponseEntity.ok(childBranches);
     }
+
+    @GetMapping("/parents")
+    public ResponseEntity<List<BranchDto>> getParentsBranches() {
+        return ResponseEntity.ok(branchService.getParentBranches());
+    }
 }

--- a/src/main/java/com/pipemasters/server/controller/BranchController.java
+++ b/src/main/java/com/pipemasters/server/controller/BranchController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/branch")
 public class BranchController {
@@ -32,5 +34,29 @@ public class BranchController {
     public ResponseEntity<BranchDto> reassignParent(@PathVariable Long id, @RequestParam(required = false) Long parentId) {
         BranchDto updated = branchService.reassignParent(id, parentId);
         return new ResponseEntity<>(updated, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BranchDto> getBranchById(@PathVariable Long id) {
+        BranchDto branch = branchService.getBranchById(id);
+        return ResponseEntity.ok(branch);
+    }
+
+    @GetMapping("/by-name")
+    public ResponseEntity<BranchDto> getBranchByName(@RequestParam String name) {
+        BranchDto branch = branchService.getBranchByName(name);
+        return ResponseEntity.ok(branch);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<BranchDto>> getAllBranches() {
+        List<BranchDto> branches = branchService.getAllBranches();
+        return ResponseEntity.ok(branches);
+    }
+
+    @GetMapping("/children/{parentId}")
+    public ResponseEntity<List<BranchDto>> getChildBranches(@PathVariable Long parentId) {
+        List<BranchDto> childBranches = branchService.getChildBranches(parentId);
+        return ResponseEntity.ok(childBranches);
     }
 }

--- a/src/main/java/com/pipemasters/server/controller/BranchController.java
+++ b/src/main/java/com/pipemasters/server/controller/BranchController.java
@@ -37,26 +37,33 @@ public class BranchController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BranchDto> getBranchById(@PathVariable Long id) {
-        BranchDto branch = branchService.getBranchById(id);
+    public ResponseEntity<BranchDto> getBranchById(
+            @PathVariable Long id,
+            @RequestParam(value = "includeParent", defaultValue = "false") boolean includeParent) {
+        BranchDto branch = branchService.getBranchById(id, includeParent);
         return ResponseEntity.ok(branch);
     }
 
     @GetMapping("/by-name")
-    public ResponseEntity<BranchDto> getBranchByName(@RequestParam String name) {
-        BranchDto branch = branchService.getBranchByName(name);
+    public ResponseEntity<BranchDto> getBranchByName(
+            @RequestParam String name,
+            @RequestParam(value = "includeParent", defaultValue = "false") boolean includeParent) {
+        BranchDto branch = branchService.getBranchByName(name, includeParent);
         return ResponseEntity.ok(branch);
     }
 
     @GetMapping("/all")
-    public ResponseEntity<List<BranchDto>> getAllBranches() {
-        List<BranchDto> branches = branchService.getAllBranches();
+    public ResponseEntity<List<BranchDto>> getAllBranches(
+            @RequestParam(value = "includeParent", defaultValue = "false") boolean includeParent) {
+        List<BranchDto> branches = branchService.getAllBranches(includeParent);
         return ResponseEntity.ok(branches);
     }
 
     @GetMapping("/children/{parentId}")
-    public ResponseEntity<List<BranchDto>> getChildBranches(@PathVariable Long parentId) {
-        List<BranchDto> childBranches = branchService.getChildBranches(parentId);
+    public ResponseEntity<List<BranchDto>> getChildBranches(
+            @PathVariable Long parentId,
+            @RequestParam(value = "includeParent", defaultValue = "false") boolean includeParent) {
+        List<BranchDto> childBranches = branchService.getChildBranches(parentId, includeParent);
         return ResponseEntity.ok(childBranches);
     }
 }

--- a/src/main/java/com/pipemasters/server/repository/BranchRepository.java
+++ b/src/main/java/com/pipemasters/server/repository/BranchRepository.java
@@ -1,7 +1,14 @@
 package com.pipemasters.server.repository;
 
 import com.pipemasters.server.entity.Branch;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface BranchRepository extends GeneralRepository<Branch, Long> {
     boolean existsByName(String name);
+    Optional<Branch> findByName(String name);
+    @Query("select b from Branch b where b.parent.id = :parentId")
+    List<Branch> findByParentId(Long parentId);
 }

--- a/src/main/java/com/pipemasters/server/repository/BranchRepository.java
+++ b/src/main/java/com/pipemasters/server/repository/BranchRepository.java
@@ -11,4 +11,5 @@ public interface BranchRepository extends GeneralRepository<Branch, Long> {
     Optional<Branch> findByName(String name);
     @Query("select b from Branch b where b.parent.id = :parentId")
     List<Branch> findByParentId(Long parentId);
+    List<Branch> findByParentIsNull();
 }

--- a/src/main/java/com/pipemasters/server/service/BranchService.java
+++ b/src/main/java/com/pipemasters/server/service/BranchService.java
@@ -8,8 +8,8 @@ public interface BranchService {
     BranchDto createBranch(BranchDto branchDto);
     BranchDto updateBranchName(Long id, String newName);
     BranchDto reassignParent(Long id, Long newParentId);
-    BranchDto getBranchById(Long id);
-    BranchDto getBranchByName(String name);
-    List<BranchDto> getAllBranches();
-    List<BranchDto> getChildBranches(Long parentId);
+    BranchDto getBranchById(Long id, boolean includeParent);
+    BranchDto getBranchByName(String name, boolean includeParent);
+    List<BranchDto> getAllBranches(boolean includeParent);
+    List<BranchDto> getChildBranches(Long parentId, boolean includeParent);
 }

--- a/src/main/java/com/pipemasters/server/service/BranchService.java
+++ b/src/main/java/com/pipemasters/server/service/BranchService.java
@@ -12,4 +12,5 @@ public interface BranchService {
     BranchDto getBranchByName(String name, boolean includeParent);
     List<BranchDto> getAllBranches(boolean includeParent);
     List<BranchDto> getChildBranches(Long parentId, boolean includeParent);
+    List<BranchDto> getParentBranches();
 }

--- a/src/main/java/com/pipemasters/server/service/BranchService.java
+++ b/src/main/java/com/pipemasters/server/service/BranchService.java
@@ -2,8 +2,14 @@ package com.pipemasters.server.service;
 
 import com.pipemasters.server.dto.BranchDto;
 
+import java.util.List;
+
 public interface BranchService {
     BranchDto createBranch(BranchDto branchDto);
     BranchDto updateBranchName(Long id, String newName);
     BranchDto reassignParent(Long id, Long newParentId);
+    BranchDto getBranchById(Long id);
+    BranchDto getBranchByName(String name);
+    List<BranchDto> getAllBranches();
+    List<BranchDto> getChildBranches(Long parentId);
 }

--- a/src/main/java/com/pipemasters/server/service/impl/BranchServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/BranchServiceImpl.java
@@ -106,6 +106,14 @@ public class BranchServiceImpl implements BranchService {
                 .toList();
     }
 
+    @Override
+    public List<BranchDto> getParentBranches() {
+        List<Branch> rootBranches = branchRepository.findByParentIsNull();
+        return rootBranches.stream()
+                .map(this::toDto)
+                .toList();
+    }
+
     private BranchDto toDto(Branch entity, boolean includeParent) {
         BranchDto dto = modelMapper.map(entity, BranchDto.class);
 

--- a/src/test/java/com/pipemasters/server/controller/BranchControllerTest.java
+++ b/src/test/java/com/pipemasters/server/controller/BranchControllerTest.java
@@ -262,4 +262,29 @@ class BranchControllerTest {
                 branchController.getChildBranches(999L, false)
         );
     }
+
+    @Test
+    void getParentsBranches_ReturnsOkStatusAndListOfRootBranches() {
+        List<BranchDto> rootBranches = Arrays.asList(mockBranchDto1);
+        when(branchService.getParentBranches()).thenReturn(rootBranches);
+
+        ResponseEntity<List<BranchDto>> response = branchController.getParentsBranches();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals(mockBranchDto1, response.getBody().get(0));
+        assertNull(response.getBody().get(0).getParent());
+    }
+
+    @Test
+    void getParentsBranches_ReturnsEmptyListWhenNoRootBranchesExist() {
+        when(branchService.getParentBranches()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<BranchDto>> response = branchController.getParentsBranches();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isEmpty());
+    }
 }

--- a/src/test/java/com/pipemasters/server/controller/BranchControllerTest.java
+++ b/src/test/java/com/pipemasters/server/controller/BranchControllerTest.java
@@ -1,7 +1,9 @@
 package com.pipemasters.server.controller;
 
 import com.pipemasters.server.dto.BranchDto;
+import com.pipemasters.server.exceptions.branch.BranchNotFoundException;
 import com.pipemasters.server.service.BranchService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -10,8 +12,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,6 +31,21 @@ class BranchControllerTest {
 
     @InjectMocks
     private BranchController branchController;
+
+    private BranchDto mockBranchDto1;
+    private BranchDto mockBranchDto2;
+
+    @BeforeEach
+    void setUp() {
+        mockBranchDto1 = new BranchDto();
+        mockBranchDto1.setId(1L);
+        mockBranchDto1.setName("Test Branch 1");
+
+        mockBranchDto2 = new BranchDto();
+        mockBranchDto2.setId(2L);
+        mockBranchDto2.setName("Test Branch 2");
+        mockBranchDto2.setParent(mockBranchDto1);
+    }
 
     @Test
     void create_ReturnsCreatedStatusAndDto() {
@@ -62,5 +86,100 @@ class BranchControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(updated, response.getBody());
+    }
+
+    @Test
+    void getBranchById_ReturnsOkStatusAndDtoWhenFound() {
+        when(branchService.getBranchById(mockBranchDto1.getId())).thenReturn(mockBranchDto1);
+
+        ResponseEntity<BranchDto> response = branchController.getBranchById(mockBranchDto1.getId());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockBranchDto1, response.getBody());
+    }
+
+    @Test
+    void getBranchById_ThrowsExceptionWhenNotFound() {
+        when(branchService.getBranchById(anyLong())).thenThrow(new BranchNotFoundException("Branch not found"));
+
+        assertThrows(BranchNotFoundException.class, () ->
+                branchController.getBranchById(999L)
+        );
+    }
+
+    @Test
+    void getBranchByName_ReturnsOkStatusAndDtoWhenFound() {
+        when(branchService.getBranchByName(mockBranchDto1.getName())).thenReturn(mockBranchDto1);
+
+        ResponseEntity<BranchDto> response = branchController.getBranchByName(mockBranchDto1.getName());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockBranchDto1, response.getBody());
+    }
+
+    @Test
+    void getBranchByName_ThrowsExceptionWhenNotFound() {
+        when(branchService.getBranchByName(anyString())).thenThrow(new BranchNotFoundException("Branch not found"));
+
+        assertThrows(BranchNotFoundException.class, () ->
+                branchController.getBranchByName("NonExistent")
+        );
+    }
+
+    @Test
+    void getAllBranches_ReturnsOkStatusAndListOfDtos() {
+        List<BranchDto> expectedBranches = Arrays.asList(mockBranchDto1, mockBranchDto2);
+        when(branchService.getAllBranches()).thenReturn(expectedBranches);
+
+        ResponseEntity<List<BranchDto>> response = branchController.getAllBranches();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(2, response.getBody().size());
+        assertEquals(expectedBranches, response.getBody());
+    }
+
+    @Test
+    void getAllBranches_ReturnsEmptyListWhenNoBranchesExist() {
+        when(branchService.getAllBranches()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<BranchDto>> response = branchController.getAllBranches();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getChildBranches_ReturnsOkStatusAndListOfDtosWhenParentIdGiven() {
+        List<BranchDto> children = Arrays.asList(mockBranchDto2);
+        when(branchService.getChildBranches(mockBranchDto1.getId())).thenReturn(children);
+
+        ResponseEntity<List<BranchDto>> response = branchController.getChildBranches(mockBranchDto1.getId());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals(children, response.getBody());
+    }
+
+    @Test
+    void getChildBranches_ReturnsEmptyListWhenNoChildrenFound() {
+        when(branchService.getChildBranches(mockBranchDto1.getId())).thenReturn(Collections.emptyList());
+
+        ResponseEntity<List<BranchDto>> response = branchController.getChildBranches(mockBranchDto1.getId());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getChildBranches_ThrowsExceptionWhenParentNotFound() {
+        when(branchService.getChildBranches(anyLong())).thenThrow(new BranchNotFoundException("Parent branch not found"));
+
+        assertThrows(BranchNotFoundException.class, () ->
+                branchController.getChildBranches(999L)
+        );
     }
 }

--- a/src/test/java/com/pipemasters/server/repository/BranchRepositoryTest.java
+++ b/src/test/java/com/pipemasters/server/repository/BranchRepositoryTest.java
@@ -104,4 +104,26 @@ class BranchRepositoryTest {
         assertNotNull(children);
         assertTrue(children.isEmpty());
     }
+
+    @Test
+    void findByParentIsNullReturnsRootBranches() {
+        Branch root1 = branchRepository.save(new Branch("Root One", null));
+        Branch root2 = branchRepository.save(new Branch("Root Two", null));
+        Branch child = branchRepository.save(new Branch("Child", root1));
+
+        List<Branch> rootBranches = branchRepository.findByParentIsNull();
+
+        assertNotNull(rootBranches);
+        assertEquals(2, rootBranches.size());
+        assertTrue(rootBranches.stream().anyMatch(b -> b.getName().equals("Root One")));
+        assertTrue(rootBranches.stream().anyMatch(b -> b.getName().equals("Root Two")));
+        assertFalse(rootBranches.stream().anyMatch(b -> b.getName().equals("Child")));
+    }
+
+    @Test
+    void findByParentIsNullReturnsEmptyListWhenNoRootBranchesExist() {
+        List<Branch> rootBranches = branchRepository.findByParentIsNull();
+        assertNotNull(rootBranches);
+        assertTrue(rootBranches.isEmpty());
+    }
 }

--- a/src/test/java/com/pipemasters/server/repository/BranchRepositoryTest.java
+++ b/src/test/java/com/pipemasters/server/repository/BranchRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -57,5 +58,50 @@ class BranchRepositoryTest {
         assertNotNull(saved.getId());
         assertNull(saved.getParent());
         assertEquals("Root", saved.getName());
+    }
+
+    @Test
+    void findByNameReturnsBranchWhenExists() {
+        Branch branch = branchRepository.save(new Branch("Unique Branch Name", null));
+        Optional<Branch> found = branchRepository.findByName("Unique Branch Name");
+        assertTrue(found.isPresent());
+        assertEquals(branch.getId(), found.get().getId());
+        assertEquals("Unique Branch Name", found.get().getName());
+    }
+
+    @Test
+    void findByNameReturnsEmptyOptionalWhenNotExists() {
+        Optional<Branch> found = branchRepository.findByName("NonExistent Branch");
+        assertTrue(found.isEmpty());
+    }
+
+    @Test
+    void findByParentIdReturnsChildrenWhenExist() {
+        Branch parent = branchRepository.save(new Branch("Parent Branch", null));
+        Branch child1 = branchRepository.save(new Branch("Child 1", parent));
+        Branch child2 = branchRepository.save(new Branch("Child 2", parent));
+        Branch unrelated = branchRepository.save(new Branch("Unrelated", null));
+
+        List<Branch> children = branchRepository.findByParentId(parent.getId());
+        assertNotNull(children);
+        assertEquals(2, children.size());
+        assertTrue(children.stream().anyMatch(b -> b.getName().equals("Child 1")));
+        assertTrue(children.stream().anyMatch(b -> b.getName().equals("Child 2")));
+        assertFalse(children.stream().anyMatch(b -> b.getName().equals("Unrelated")));
+    }
+
+    @Test
+    void findByParentIdReturnsEmptyListWhenNoChildren() {
+        Branch parent = branchRepository.save(new Branch("Parent No Children", null));
+        List<Branch> children = branchRepository.findByParentId(parent.getId());
+        assertNotNull(children);
+        assertTrue(children.isEmpty());
+    }
+
+    @Test
+    void findByParentIdReturnsEmptyListForNonExistentParent() {
+        List<Branch> children = branchRepository.findByParentId(999L);
+        assertNotNull(children);
+        assertTrue(children.isEmpty());
     }
 }

--- a/src/test/java/com/pipemasters/server/service/BranchServiceImplTest.java
+++ b/src/test/java/com/pipemasters/server/service/BranchServiceImplTest.java
@@ -315,4 +315,34 @@ class BranchServiceImplTest {
                 branchService.getChildBranches(999L, anyBoolean())
         );
     }
+
+    @Test
+    void getRootBranches_shouldReturnListOfParentBranches() {
+        List<Branch> rootEntities = Arrays.asList(mockBranch1);
+        when(branchRepository.findByParentIsNull()).thenReturn(rootEntities);
+
+        BranchDto simpleRootDto = new BranchDto();
+        simpleRootDto.setId(mockBranch1.getId());
+        simpleRootDto.setName(mockBranch1.getName());
+        simpleRootDto.setParent(null);
+
+        when(modelMapper.map(mockBranch1, BranchDto.class)).thenReturn(simpleRootDto);
+
+        List<BranchDto> result = branchService.getParentBranches();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(simpleRootDto, result.get(0));
+        assertNull(result.get(0).getParent());
+    }
+
+    @Test
+    void getRootBranches_shouldReturnEmptyListWhenNoParentBranchesExist() {
+        when(branchRepository.findByParentIsNull()).thenReturn(Collections.emptyList());
+
+        List<BranchDto> result = branchService.getParentBranches();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
 }


### PR DESCRIPTION
Добавлены методы для получения филиалов по:
Id, названию, для всех филиалов, для всех дочерних филиалов по id родительского, все родительские филиалы.
Добавлены тесты