### PR TITLE
Исправлена рекурсия в upload-batch-controller

### DIFF
--- a/src/main/java/com/pipemasters/server/controller/UploadBatchController.java
+++ b/src/main/java/com/pipemasters/server/controller/UploadBatchController.java
@@ -1,7 +1,7 @@
 package com.pipemasters.server.controller;
 
-import com.pipemasters.server.dto.UploadBatchDto;
 import com.pipemasters.server.dto.UploadBatchFilter;
+import com.pipemasters.server.dto.UploadBatchResponseDto;
 import com.pipemasters.server.service.UploadBatchService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +28,7 @@ public class UploadBatchController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<UploadBatchDto>> getFiltered(
+    public ResponseEntity<Page<UploadBatchResponseDto>> getFiltered(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFrom,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateTo,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate specificDate,

--- a/src/main/java/com/pipemasters/server/dto/UploadBatchResponseDto.java
+++ b/src/main/java/com/pipemasters/server/dto/UploadBatchResponseDto.java
@@ -1,0 +1,148 @@
+package com.pipemasters.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UploadBatchResponseDto extends BaseDto{
+    private String directory;
+    private Long uploadedId;
+    private Instant createdAt;
+    private LocalDate trainDeparted;
+    private Long trainId;
+    private String comment;
+    private Set<String> keywords = new HashSet<>();
+    private Long branchId;
+    private boolean archived;
+    private Instant deletedAt;
+    private boolean deleted;
+    private MediaFileResponseDto file;
+    private Long absenceId;
+
+    public UploadBatchResponseDto() {
+    }
+
+    public UploadBatchResponseDto(String directory, Long uploadedId, Instant createdAt, LocalDate trainDeparted, Long trainId, String comment, Set<String> keywords, Long branchId, boolean archived, Instant deletedAt, boolean deleted, MediaFileResponseDto file, Long absenceId) {
+        this.directory = directory;
+        this.uploadedId = uploadedId;
+        this.createdAt = createdAt;
+        this.trainDeparted = trainDeparted;
+        this.trainId = trainId;
+        this.comment = comment;
+        this.keywords = keywords;
+        this.branchId = branchId;
+        this.archived = archived;
+        this.deletedAt = deletedAt;
+        this.deleted = deleted;
+        this.file = file;
+        this.absenceId = absenceId;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    public Long getUploadedId() {
+        return uploadedId;
+    }
+
+    public void setUploadedId(Long uploadedId) {
+        this.uploadedId = uploadedId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDate getTrainDeparted() {
+        return trainDeparted;
+    }
+
+    public void setTrainDeparted(LocalDate trainDeparted) {
+        this.trainDeparted = trainDeparted;
+    }
+
+    public Long getTrainId() {
+        return trainId;
+    }
+
+    public void setTrainId(Long trainId) {
+        this.trainId = trainId;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Set<String> getKeywords() {
+        return keywords;
+    }
+
+    public void setKeywords(Set<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    public Long getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(Long branchId) {
+        this.branchId = branchId;
+    }
+
+    public boolean isArchived() {
+        return archived;
+    }
+
+    public void setArchived(boolean archived) {
+        this.archived = archived;
+    }
+
+    public Instant getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(Instant deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
+    public MediaFileResponseDto getFile() {
+        return file;
+    }
+
+    public void setFile(MediaFileResponseDto file) {
+        this.file = file;
+    }
+
+    public Long getAbsenceId() {
+        return absenceId;
+    }
+
+    public void setAbsenceId(Long absenceId) {
+        this.absenceId = absenceId;
+    }
+}

--- a/src/main/java/com/pipemasters/server/service/UploadBatchService.java
+++ b/src/main/java/com/pipemasters/server/service/UploadBatchService.java
@@ -3,16 +3,14 @@ package com.pipemasters.server.service;
 import java.util.List;
 import com.pipemasters.server.dto.UploadBatchDto;
 import com.pipemasters.server.dto.UploadBatchFilter;
+import com.pipemasters.server.dto.UploadBatchResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface UploadBatchService {
-
-
-
     UploadBatchDto save(UploadBatchDto uploadBatchDto);
+    Page<UploadBatchResponseDto> getFilteredBatches(UploadBatchFilter filter, Pageable pageable);
     UploadBatchDto getById(Long id);
     List<UploadBatchDto> getAll();
     UploadBatchDto updateUploadBatchDto(Long uploadBatchId, UploadBatchDto dto);
-    Page<UploadBatchDto> getFilteredBatches(UploadBatchFilter filter, Pageable pageable);
 }

--- a/src/main/java/com/pipemasters/server/service/impl/UploadBatchServiceImpl.java
+++ b/src/main/java/com/pipemasters/server/service/impl/UploadBatchServiceImpl.java
@@ -1,14 +1,11 @@
 package com.pipemasters.server.service.impl;
 
-import com.pipemasters.server.dto.FileUploadRequestDto;
+import com.pipemasters.server.dto.MediaFileResponseDto;
 import com.pipemasters.server.dto.UploadBatchDto;
-import com.pipemasters.server.dto.UserDto;
-import com.pipemasters.server.entity.Branch;
 import com.pipemasters.server.dto.UploadBatchFilter;
+import com.pipemasters.server.dto.UploadBatchResponseDto;
 import com.pipemasters.server.entity.UploadBatch;
-import com.pipemasters.server.entity.User;
 import com.pipemasters.server.entity.enums.FileType;
-import com.pipemasters.server.repository.MediaFileRepository;
 import com.pipemasters.server.repository.UploadBatchRepository;
 import com.pipemasters.server.repository.specifications.UploadBatchSpecifications;
 import com.pipemasters.server.service.UploadBatchService;
@@ -28,17 +25,14 @@ public class UploadBatchServiceImpl implements UploadBatchService {
 
     private final UploadBatchRepository uploadBatchRepository;
     private final ModelMapper modelMapper;
-    private final FileServiceImpl fileService;
-    private final MediaFileRepository mediaFileRepository;
 
-    public UploadBatchServiceImpl(UploadBatchRepository uploadBatchRepository, ModelMapper modelMapper, FileServiceImpl fileService, MediaFileRepository mediaFileRepository) {
+    public UploadBatchServiceImpl(UploadBatchRepository uploadBatchRepository, ModelMapper modelMapper) {
         this.uploadBatchRepository = uploadBatchRepository;
         this.modelMapper = modelMapper;
-        this.fileService = fileService;
-        this.mediaFileRepository = mediaFileRepository;
     }
 
     @Override
+    @Transactional
     public UploadBatchDto save(UploadBatchDto uploadBatchDto) {
         var now = Instant.now();
         uploadBatchDto.setDirectory(String.valueOf(UUID.randomUUID()));
@@ -51,24 +45,38 @@ public class UploadBatchServiceImpl implements UploadBatchService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<UploadBatchDto> getFilteredBatches(UploadBatchFilter filter, Pageable pageable) {
+    public Page<UploadBatchResponseDto> getFilteredBatches(UploadBatchFilter filter, Pageable pageable) {
         Page<UploadBatch> page = uploadBatchRepository.findAll(UploadBatchSpecifications.withFilter(filter), pageable);
-        return page.map(batch -> modelMapper.map(batch, UploadBatchDto.class));
+        return page.map(batch -> {
+            UploadBatchResponseDto dto = modelMapper.map(batch, UploadBatchResponseDto.class);
+            batch.getFiles().stream()
+                    .filter(mediaFile -> FileType.VIDEO.equals(mediaFile.getFileType()))
+                    .findFirst()
+                    .ifPresent(videoMediaFile -> {
+                        MediaFileResponseDto mediaFileDto = modelMapper.map(videoMediaFile, MediaFileResponseDto.class);
+                        dto.setFile(mediaFileDto);
+                    });
+
+            return dto;
+        });
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UploadBatchDto getById(Long id) {
         var uploadBatch = uploadBatchRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("UploadBatch not found"));
         return modelMapper.map(uploadBatch,UploadBatchDto.class);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<UploadBatchDto> getAll() {
         return uploadBatchRepository.findAll().stream()
                 .map(uploadBatch -> modelMapper.map(uploadBatch,UploadBatchDto.class)).toList();
     }
 
     @Override
+    @Transactional
     public UploadBatchDto updateUploadBatchDto(Long uploadBatchId, UploadBatchDto dto) {
         var uploadBatchOrigin = uploadBatchRepository.findById(uploadBatchId)
                 .orElseThrow(() -> new RuntimeException("UploadBatch not found with ID: " + uploadBatchId));

--- a/src/test/java/com/pipemasters/server/controller/UploadBatchControllerTest.java
+++ b/src/test/java/com/pipemasters/server/controller/UploadBatchControllerTest.java
@@ -1,23 +1,32 @@
 package com.pipemasters.server.controller;
 
-import com.pipemasters.server.dto.UploadBatchDto;
 import com.pipemasters.server.dto.UploadBatchFilter;
+import com.pipemasters.server.dto.UploadBatchResponseDto;
 import com.pipemasters.server.service.UploadBatchService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class UploadBatchControllerTest {
@@ -28,22 +37,43 @@ class UploadBatchControllerTest {
     @InjectMocks
     private UploadBatchController uploadBatchController;
 
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(uploadBatchController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
     @Test
     void getFiltered_ReturnsOkStatusAndPage() {
-        // given
-        UploadBatchDto dto1 = new UploadBatchDto();
-        UploadBatchDto dto2 = new UploadBatchDto();
-        List<UploadBatchDto> dtos = List.of(dto1, dto2);
+        UploadBatchResponseDto dto1 = new UploadBatchResponseDto();
+        dto1.setDirectory(UUID.randomUUID().toString());
+        dto1.setUploadedId(1L);
+        dto1.setCreatedAt(Instant.now());
+        dto1.setTrainDeparted(LocalDate.of(2024, 1, 1));
+        dto1.setTrainId(101L);
+        dto1.setBranchId(201L);
+
+        UploadBatchResponseDto dto2 = new UploadBatchResponseDto();
+        dto2.setDirectory(UUID.randomUUID().toString());
+        dto2.setUploadedId(2L);
+        dto2.setCreatedAt(Instant.now());
+        dto2.setTrainDeparted(LocalDate.of(2024, 1, 2));
+        dto2.setTrainId(102L);
+        dto2.setBranchId(202L);
+
+        List<UploadBatchResponseDto> dtos = List.of(dto1, dto2);
         Pageable pageable = PageRequest.of(0, 15, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<UploadBatchDto> page = new PageImpl<>(dtos, pageable, dtos.size());
+        Page<UploadBatchResponseDto> page = new PageImpl<>(dtos, pageable, dtos.size());
 
         when(uploadBatchService.getFilteredBatches(any(UploadBatchFilter.class), any(Pageable.class)))
                 .thenReturn(page);
 
         Set<String> keywords = Set.of("ключевое", "видео", "путь");
 
-        // when
-        ResponseEntity<Page<UploadBatchDto>> response = uploadBatchController.getFiltered(
+        ResponseEntity<Page<UploadBatchResponseDto>> response = uploadBatchController.getFiltered(
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2024, 12, 31),
                 null,
@@ -54,9 +84,42 @@ class UploadBatchControllerTest {
                 pageable
         );
 
-        // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(page, response.getBody());
+        verify(uploadBatchService).getFilteredBatches(any(UploadBatchFilter.class), any(Pageable.class));
+    }
+
+    @Test
+    void getFiltered_shouldNotCauseRecursionInJsonSerialization() throws Exception {
+        UploadBatchResponseDto recursiveDto = new UploadBatchResponseDto();
+        recursiveDto.setDirectory(UUID.randomUUID().toString());
+        recursiveDto.setUploadedId(1L);
+        recursiveDto.setCreatedAt(Instant.now());
+        recursiveDto.setTrainDeparted(LocalDate.of(2024, 1, 1));
+        recursiveDto.setTrainId(101L);
+        recursiveDto.setBranchId(201L);
+
+        List<UploadBatchResponseDto> dtos = List.of(recursiveDto);
+        Pageable pageable = PageRequest.of(0, 15, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<UploadBatchResponseDto> page = new PageImpl<>(dtos, pageable, dtos.size());
+
+        when(uploadBatchService.getFilteredBatches(any(UploadBatchFilter.class), any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/v1/batch")
+                        .param("dateFrom", "2024-01-01")
+                        .param("dateTo", "2024-12-31")
+                        .param("trainNumber", "123")
+                        .param("chiefName", "Иванов")
+                        .param("uploadedByName", "Петров")
+                        .param("keywords", "ключевое", "видео", "путь")
+                        .param("page", "0")
+                        .param("size", "15")
+                        .param("sort", "createdAt,desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
         verify(uploadBatchService).getFilteredBatches(any(UploadBatchFilter.class), any(Pageable.class));
     }
 }

--- a/src/test/java/com/pipemasters/server/service/UploadBatchServiceImplTest.java
+++ b/src/test/java/com/pipemasters/server/service/UploadBatchServiceImplTest.java
@@ -1,8 +1,12 @@
 package com.pipemasters.server.service;
 
+import com.pipemasters.server.dto.MediaFileResponseDto;
 import com.pipemasters.server.dto.UploadBatchDto;
 import com.pipemasters.server.dto.UploadBatchFilter;
+import com.pipemasters.server.dto.UploadBatchResponseDto;
+import com.pipemasters.server.entity.MediaFile;
 import com.pipemasters.server.entity.UploadBatch;
+import com.pipemasters.server.entity.enums.FileType;
 import com.pipemasters.server.repository.UploadBatchRepository;
 import com.pipemasters.server.service.impl.UploadBatchServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -20,7 +24,6 @@ import org.springframework.data.jpa.domain.Specification;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
-import org.mockito.Mock;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -32,8 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.InjectMocks;
-import static org.mockito.ArgumentMatchers.any;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -176,25 +177,107 @@ class UploadBatchServiceImplTest {
     }
 
     @Test
-    void getFilteredBatches_shouldReturnMappedPage() {
+    void getFilteredBatches_ShouldReturnPagedListOfResponseDtosWithVideoFile() {
         UploadBatchFilter filter = new UploadBatchFilter();
         Pageable pageable = PageRequest.of(0, 10);
 
-        UploadBatch entity = new UploadBatch();
-        UploadBatchDto dto = new UploadBatchDto();
+        UploadBatch batch1 = new UploadBatch();
+        batch1.setId(1L);
+        batch1.setComment("Batch 1 with video");
+        batch1.setDirectory(UUID.randomUUID());
+        MediaFile videoFile1 = new MediaFile("video1.mp4", FileType.VIDEO, Instant.now(), null, batch1);
+        MediaFile audioFile1 = new MediaFile("audio1.mp3", FileType.AUDIO, Instant.now(), null, batch1);
+        batch1.setFiles(Arrays.asList(videoFile1, audioFile1));
 
-        Page<UploadBatch> entityPage = new PageImpl<>(List.of(entity));
-        when(uploadBatchRepository.findAll(any(Specification.class), eq(pageable)))
-                .thenReturn(entityPage);
-        when(modelMapper.map(entity, UploadBatchDto.class)).thenReturn(dto);
+        UploadBatch batch2 = new UploadBatch();
+        batch2.setId(2L);
+        batch2.setComment("Batch 2 without video");
+        batch2.setDirectory(UUID.randomUUID());
+        MediaFile imageFile2 = new MediaFile("image2.jpg", FileType.IMAGE, Instant.now(), null, batch2);
+        batch2.setFiles(Collections.singletonList(imageFile2));
 
-        Page<UploadBatchDto> result = uploadBatchService.getFilteredBatches(filter, pageable);
+        UploadBatch batch3 = new UploadBatch();
+        batch3.setId(3L);
+        batch3.setComment("Batch 3 with video");
+        batch3.setDirectory(UUID.randomUUID());
+        MediaFile videoFile3 = new MediaFile("video3.mp4", FileType.VIDEO, Instant.now(), null, batch3);
+        batch3.setFiles(Collections.singletonList(videoFile3));
 
-        assertEquals(1, result.getTotalElements());
-        assertEquals(dto, result.getContent().getFirst());
+        List<UploadBatch> entities = Arrays.asList(batch1, batch2, batch3);
+        Page<UploadBatch> entityPage = new PageImpl<>(entities, pageable, entities.size());
+
+        when(uploadBatchRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(entityPage);
+
+        UploadBatchResponseDto responseDto1 = new UploadBatchResponseDto();
+        responseDto1.setId(1L);
+        responseDto1.setComment("Batch 1 with video");
+        when(modelMapper.map(batch1, UploadBatchResponseDto.class)).thenReturn(responseDto1);
+
+        UploadBatchResponseDto responseDto2 = new UploadBatchResponseDto();
+        responseDto2.setId(2L);
+        responseDto2.setComment("Batch 2 without video");
+        when(modelMapper.map(batch2, UploadBatchResponseDto.class)).thenReturn(responseDto2);
+
+        UploadBatchResponseDto responseDto3 = new UploadBatchResponseDto();
+        responseDto3.setId(3L);
+        responseDto3.setComment("Batch 3 with video");
+        when(modelMapper.map(batch3, UploadBatchResponseDto.class)).thenReturn(responseDto3);
+
+        MediaFileResponseDto videoDto1 = new MediaFileResponseDto();
+        videoDto1.setFilename("video1.mp4");
+        videoDto1.setFileType(FileType.VIDEO);
+        when(modelMapper.map(videoFile1, MediaFileResponseDto.class)).thenReturn(videoDto1);
+
+        MediaFileResponseDto videoDto3 = new MediaFileResponseDto();
+        videoDto3.setFilename("video3.mp4");
+        videoDto3.setFileType(FileType.VIDEO);
+        when(modelMapper.map(videoFile3, MediaFileResponseDto.class)).thenReturn(videoDto3);
+
+        Page<UploadBatchResponseDto> resultPage = uploadBatchService.getFilteredBatches(filter, pageable);
+
+        assertNotNull(resultPage);
+        assertEquals(3, resultPage.getTotalElements());
+        assertEquals(3, resultPage.getContent().size());
+
+        UploadBatchResponseDto dto1Result = resultPage.getContent().get(0);
+        assertEquals(1L, dto1Result.getId());
+        assertEquals("Batch 1 with video", dto1Result.getComment());
+        assertNotNull(dto1Result.getFile());
+        assertEquals("video1.mp4", dto1Result.getFile().getFilename());
+        assertEquals(FileType.VIDEO, dto1Result.getFile().getFileType());
+
+        UploadBatchResponseDto dto2Result = resultPage.getContent().get(1);
+        assertEquals(2L, dto2Result.getId());
+        assertEquals("Batch 2 without video", dto2Result.getComment());
+        assertNull(dto2Result.getFile());
+
+        UploadBatchResponseDto dto3Result = resultPage.getContent().get(2);
+        assertEquals(3L, dto3Result.getId());
+        assertEquals("Batch 3 with video", dto3Result.getComment());
+        assertNotNull(dto3Result.getFile());
+        assertEquals("video3.mp4", dto3Result.getFile().getFilename());
+        assertEquals(FileType.VIDEO, dto3Result.getFile().getFileType());
 
         verify(uploadBatchRepository).findAll(any(Specification.class), eq(pageable));
-        verify(modelMapper).map(entity, UploadBatchDto.class);
+        verify(modelMapper, times(3)).map(any(UploadBatch.class), eq(UploadBatchResponseDto.class));
+        verify(modelMapper, times(2)).map(any(MediaFile.class), eq(MediaFileResponseDto.class));
     }
 
+    @Test
+    void getFilteredBatches_ShouldReturnEmptyPageWhenNoBatchesFound() {
+        UploadBatchFilter filter = new UploadBatchFilter();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<UploadBatch> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+        when(uploadBatchRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(emptyPage);
+
+        Page<UploadBatchResponseDto> resultPage = uploadBatchService.getFilteredBatches(filter, pageable);
+
+        assertNotNull(resultPage);
+        assertTrue(resultPage.isEmpty());
+        assertEquals(0, resultPage.getTotalElements());
+        verify(uploadBatchRepository).findAll(any(Specification.class), eq(pageable));
+        verify(modelMapper, never()).map(any(UploadBatch.class), eq(UploadBatchResponseDto.class));
+        verify(modelMapper, never()).map(any(MediaFile.class), eq(MediaFileResponseDto.class));
+    }
 }


### PR DESCRIPTION
Добавлено UploadBatchResponseDto откуда было убрано большинство вложенных сущностей.
Исправлена логика в UploadBatchServiceImpl в методе getFilteredBatches. Теперь передаем только один MediaFile, который имеет тип VIDEO, если их несколько выбирается первый.
Добавлен тест на проверку отсутствия рекурсии.
Переделан тест для метода getFilteredBatches в сервисе.
Добавлены аннотации @transactional где их не было